### PR TITLE
Fix README port and start script

### DIFF
--- a/Simple-Node-Js-App/Readme.md
+++ b/Simple-Node-Js-App/Readme.md
@@ -39,7 +39,7 @@ cd web-app
 
 ``` npm start ```
 
-This will run the application on 'http://localhost:8080'
+This will run the application on 'http://localhost:3000'
 
 
 # Docker Build

--- a/Simple-Node-Js-App/web-app/package.json
+++ b/Simple-Node-Js-App/web-app/package.json
@@ -1,8 +1,9 @@
 {
   "name": "web-app",
   "version": "1.0.0",
-  "main": "index.js",
+  "main": "app.js",
   "scripts": {
+    "start": "node app.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- correct README to show port 3000
- add a `start` script in `package.json` and set main entry

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails due to missing dependencies)*

------
